### PR TITLE
feat(common): Add support for specifying default S3 region when it cannot be determined from the URL

### DIFF
--- a/src/content/docs/truecharts-common/credentials.md
+++ b/src/content/docs/truecharts-common/credentials.md
@@ -90,6 +90,13 @@ credentials:
 
 Define the url of the credentials
 
+:::tip
+
+In some cases, such as when using an IP instead of a hostname, it might be
+necessary to manually specify the connection's [region](/truecharts-common/credentials#region).
+
+:::
+
 |            |                          |
 | ---------- | ------------------------ |
 | Key        | `credentials.$name.url`  |
@@ -102,6 +109,33 @@ Define the url of the credentials
 credentials:
   credentials-name:
     url: "https://mys3server.com"
+```
+
+---
+
+#### `region`
+
+Override the region to use when connecting to the endpoint
+
+:::note
+
+Setting this manually is usually not necessary as the region should normally
+be automatically detected from the [URL](/truecharts-common/credentials#url).
+
+:::
+
+|            |                            |
+| ---------- | -------------------------- |
+| Key        | `credentials.$name.region` |
+| Type       | `string`                   |
+| Required   | ❌                         |
+| Helm `tpl` | ❌                         |
+| Example    | `""`                       |
+
+```yaml
+credentials:
+  credentials-name:
+    region: "us-east-1"
 ```
 
 ---


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

Docs part of https://github.com/trueforge-org/truecharts/pull/40668

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [X] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [X] 📄 I have made changes to the documentation
- [X] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [X] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
